### PR TITLE
Adding diagnostics for unsupported option

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1897,6 +1897,15 @@ bool CompilerInvocation::ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args,
     Opts.setInlining(CodeGenOptions::NormalInlining);
   }
 
+// -mcmodel option.
+if (const llvm::opt::Arg *A = Args.getLastArg(clang::driver::options::OPT_mcmodel_EQ)) 
+{
+    llvm::StringRef modelName = A->getValue();
+    if(modelName=="tiny" && !T.isARM())
+      Diags.Report(diag::err_drv_unsupported_option_argument_for_target) 
+              << A->getSpelling() <<modelName<< T.getTriple();  
+}
+
   // PIC defaults to -fno-direct-access-external-data while non-PIC defaults to
   // -fdirect-access-external-data.
   Opts.DirectAccessExternalData =


### PR DESCRIPTION
The tiny option in the mcmodel is supported only by ARM targets. In cases where this option was passed with a non-ARM architecture, the compiler previously threw an error from the backend with a stack trace. This fix changes the behavior to issue a diagnostic error, instead of throwing a backend error.