### PR TITLE
Trying to fix undefined symbol error caused by iterator variable

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4461,6 +4461,13 @@ def OMPCaptureKind : Attr {
   }];
 }
 
+def OMPIterator : Attr {
+  // This attribute has no spellings as it is only ever created implicitly.
+  let Spellings = [];
+  let SemaHandler = 0;
+  let Documentation = [InternalOnly];
+}
+
 def OMPReferencedVar : Attr {
   // This attribute has no spellings as it is only ever created implicitly.
   let Spellings = [];

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -2969,6 +2969,11 @@ static LValue EmitGlobalVarDeclLValue(CodeGenFunction &CGF,
 
   llvm::Value *V = CGF.CGM.GetAddrOfGlobalVar(VD);
 
+  if (VD->hasAttr<OMPIteratorAttr>()) {
+  llvm::GlobalVariable *Var = llvm::dyn_cast<llvm::GlobalVariable>(V);
+  Var->setInitializer(CGF.CGM.EmitNullConstant(E->getType()));
+  }
+
   if (VD->getTLSKind() != VarDecl::TLS_None)
     V = CGF.Builder.CreateThreadLocalAddress(V);
 

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -24476,6 +24476,8 @@ ExprResult SemaOpenMP::ActOnOMPIteratorExpr(Scope *S,
         VarDecl::Create(Context, SemaRef.CurContext, StartLoc, D.DeclIdentLoc,
                         D.DeclIdent, DeclTy, TInfo, SC_None);
     VD->setImplicit();
+    VD->addAttr(OMPIteratorAttr::CreateImplicit(
+        Context, SourceRange(StartLoc)));
     if (S) {
       // Check for conflicting previous declaration.
       DeclarationNameInfo NameInfo(VD->getDeclName(), D.DeclIdentLoc);


### PR DESCRIPTION
When a mapper is declared with an iterator variable inside the map clause, it results in unintended behavior due to the iterator being implicitly created but left uninitialized.
Testcase:

```
typedef struct myvec{
    size_t len;
    double *data;
} myvec_t;

#pragma omp declare mapper(id:myvec_t v) map( iterator( iterator_variable=0:v.len), tofrom: v.data[iterator_variable]) 

int main() 
{ 
    int errors = 0;
   myvec_t s;
   #pragma omp target map(mapper(id), to:s)
     {
     }
  return 0;
}
```
The error we get while compiling this is:
```
/usr/lib64/gcc/x86_64-suse-linux/14/../../../../x86_64-suse-linux/bin/ld: /tmp/test-f70647.o: in function `.omp_mapper._ZTS5myvec.id':
test.cpp:(.text+0x21a): undefined reference to `iterator_variable'
/llvm-project/install/bin/clang-linker-wrapper: error: 'ld' failed
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
 This patch tries to fix this by initializing the iterator variable to a null constant.